### PR TITLE
add build essential and mocha to travis before_install hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+before_install:
+ - sudo apt-get install build-essential
+ - npm i mocha -g
 node_js:
     - "0.10"
     - "0.8"


### PR DESCRIPTION
with that PR travis works.

Also note that node0.8 is not compatible with the current sources, npm install fails.
Can see more here https://travis-ci.org/maboiteaspam/cozy-light/jobs/40054128
